### PR TITLE
docs: document the justfile task runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@ architecture/design patterns) for the full target design before adding new domai
 
 ## Commands
 
+- **Task runner:** a `justfile` wraps the common commands (`just` lists them). Prefer it for dev work:
+  `just up`, `just db-setup`, `just test [path]`, `just lint`, `just ci`, `just sh`, `just console`.
+  DB-touching recipes run **inside the `app` container** (host `db` only resolves on the Docker
+  network — running `bin/rails`/`rspec`/`bin/ci` on the host fails name resolution). Needs `just`
+  (`sudo apt install just`). Raw equivalents below:
 - Run app (Docker): `docker compose up --build`, then `docker compose exec app bin/rails db:create db:migrate`
 - Run all tests: `bundle exec rspec`
 - Run a single test file: `bundle exec rspec spec/models/cabin_spec.rb`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ The project is fully Dockerized for an easy setup.
 
 The application runs at: `http://localhost:3000`.
 
+> **Tip:** the repo ships a [`justfile`](justfile) with shortcuts (install `just` via
+> `sudo apt install just`). E.g. `just up`, `just db-setup`, `just test`, `just lint`,
+> `just ci`, `just sh`. Run `just` to list them. DB-touching recipes run inside the
+> container automatically.
+
 > The `app` and `sidekiq` services wait for healthy `db`, `redis`, and `elasticsearch`
 > containers before booting (Compose healthchecks), so the first `up` won't crash on a
 > not-yet-ready database. Postgres is exposed on host port **5433** to avoid clashing
@@ -82,6 +87,9 @@ bundle exec rspec spec/models/cabin_spec.rb   # one file
 bundle exec rubocop                      # lint (rubocop-rails-omakase)
 bundle exec brakeman                     # security scan
 ```
+
+Or via `just` (runs inside the container, so the DB connects): `just test`,
+`just test spec/models/cabin_spec.rb`, `just lint`, `just brakeman`, `just ci`.
 
 ---
 

--- a/docs/chatahub_project_plan.md
+++ b/docs/chatahub_project_plan.md
@@ -28,6 +28,7 @@ Ukázať schopnosť navrhnúť, implementovať a nasadiť produkčne pripravenú
 | **Payments**        | Stripe (Apple Pay + Google Pay)              |
 | **Testing**         | RSpec + FactoryBot + SimpleCov               |
 | **CI/CD**           | GitHub Actions                               |
+| **Dev tooling**     | just (task runner) + Docker Compose          |
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the `justfile` added in #49 across the docs.

- **CLAUDE.md**: `just` shortcuts + note that DB-touching recipes run inside the container
- **README.md**: `just` tips in Getting Started and Testing
- **docs/chatahub_project_plan.md**: add `just` to the tech-stack table

## Type of change

- [x] docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)